### PR TITLE
fixing alpine version number

### DIFF
--- a/4-Containerized_Development_With_Volumes/Dockerfile
+++ b/4-Containerized_Development_With_Volumes/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:7.6-alpine
+FROM node:8.10-alpine
 
 RUN mkdir -p /src/app
 


### PR DESCRIPTION
<img width="733" alt="Screen Shot 2019-12-10 at 5 25 20 PM" src="https://user-images.githubusercontent.com/54456684/70583297-24739e00-1b72-11ea-991c-2a17a3b8d600.png">

Hi Dylan! I received this error, and when I changed `FROM node:7.6-alpine` to `FROM node:8.10-alpine` it worked. 

Also thanks for creating this repo! It's been extremely helpful :) 